### PR TITLE
Updated at timestamps

### DIFF
--- a/RepoMan/RepoMan.UnitTests/ScorerTests.cs
+++ b/RepoMan/RepoMan.UnitTests/ScorerTests.cs
@@ -48,7 +48,6 @@ namespace RepoMan.UnitTests
                 Id = 1233456789,
                 Number = 123,
                 CommitComments = new List<Comment>(),
-                IsFullyInterrogated = true,
             };
         }
     }

--- a/RepoMan/RepoMan/Analysis/RepositoryAnalyzer.cs
+++ b/RepoMan/RepoMan/Analysis/RepositoryAnalyzer.cs
@@ -29,7 +29,7 @@ namespace RepoMan.Analysis
             var repoMetrics = new RepositoryMetrics
             {
                 Timestamp = _clock.DateTimeOffsetUtcNow(),
-                PullRequestCount = snapshots.Count,
+                PullRequests = new HashSet<int>(snapshots.Select(s => s.Number)),
                 MedianSecondsToPullRequestClosure = (int) medianTimeToClosure.TotalSeconds,
                 MedianBusinessDaysToPullRequestClosure = medianBusinessDaysToClose,
                 MedianCommentCountPerPullRequest = medianCommentCount,
@@ -44,7 +44,10 @@ namespace RepoMan.Analysis
     public class RepositoryMetrics
     {
         public DateTimeOffset Timestamp { get; set; }
-        public int PullRequestCount { get; set; }
+        
+        public HashSet<int> PullRequests { get; set; }
+        public int PullRequestCount => PullRequests.Count;
+        
         public int MedianCommentCountPerPullRequest { get; set; }
         public int MedianWordsPerComment { get; set; }
         

--- a/RepoMan/RepoMan/Repository/GitHubRepoPullRequestReader.cs
+++ b/RepoMan/RepoMan/Repository/GitHubRepoPullRequestReader.cs
@@ -86,7 +86,6 @@ namespace RepoMan.Repository
             pullRequest.UpdateDiffComments(diffReviewCommentsTask.Result);
             pullRequest.UpdateDiscussionComments(generalPrCommentsTask.Result);
             pullRequest.UpdateStateTransitionComments(approvalSummariesTask.Result);
-            pullRequest.IsFullyInterrogated = true;
 
             return true;
         }

--- a/RepoMan/RepoMan/Repository/IRepoManager.cs
+++ b/RepoMan/RepoMan/Repository/IRepoManager.cs
@@ -14,7 +14,7 @@ namespace RepoMan.Repository
         /// of the approvals, comments, and other information required to construct a complete record of the pull request's details.
         /// </summary>
         /// <param name="stateFilter"></param>
-        /// <returns></returns>
+        /// <returns>A collection of all of the new or updated pull requests that were unknown to or had to be updated in the manager</returns>
         Task<IList<PullRequestDetails>> RefreshFromUpstreamAsync(ItemStateFilter stateFilter);
         
         /// <summary>

--- a/RepoMan/RepoMan/Repository/IRepoManager.cs
+++ b/RepoMan/RepoMan/Repository/IRepoManager.cs
@@ -15,7 +15,7 @@ namespace RepoMan.Repository
         /// </summary>
         /// <param name="stateFilter"></param>
         /// <returns></returns>
-        Task<IDictionary<int, PullRequestDetails>> RefreshFromUpstreamAsync(ItemStateFilter stateFilter);
+        Task<IList<PullRequestDetails>> RefreshFromUpstreamAsync(ItemStateFilter stateFilter);
         
         /// <summary>
         /// Returns the number of pull requests in the cache that have been fully populated

--- a/RepoMan/RepoMan/Repository/IRepoManager.cs
+++ b/RepoMan/RepoMan/Repository/IRepoManager.cs
@@ -15,7 +15,7 @@ namespace RepoMan.Repository
         /// </summary>
         /// <param name="stateFilter"></param>
         /// <returns></returns>
-        Task RefreshFromUpstreamAsync(ItemStateFilter stateFilter);
+        Task<IDictionary<int, PullRequestDetails>> RefreshFromUpstreamAsync(ItemStateFilter stateFilter);
         
         /// <summary>
         /// Returns the number of pull requests in the cache that have been fully populated

--- a/RepoMan/RepoMan/Repository/PullRequestDetails.cs
+++ b/RepoMan/RepoMan/Repository/PullRequestDetails.cs
@@ -58,8 +58,6 @@ namespace RepoMan.Repository
         /// </summary>
         public List<Comment> CommitComments { get; set; } = new List<Comment>();
         
-        public bool IsFullyInterrogated { get; set; }
-        
         /// <summary>
         /// The comments associated with a line of code, or range of lines of code.
         /// </summary>

--- a/RepoMan/RepoMan/Repository/RepoWorker.cs
+++ b/RepoMan/RepoMan/Repository/RepoWorker.cs
@@ -42,22 +42,21 @@ namespace RepoMan.Repository
             _logger.Information($"{Name} work loop starting");
             var timer = Stopwatch.StartNew();
             
-            await _repoManager.RefreshFromUpstreamAsync(ItemStateFilter.Closed);
-            var pullRequestSnapshots = await _repoManager.GetPullRequestsAsync();
+            var newPrs = await _repoManager.RefreshFromUpstreamAsync(ItemStateFilter.Closed);
 
-            _logger.Information($"{Name} comment analysis starting for {pullRequestSnapshots.Count:N0} pull requests");
+            _logger.Information($"{Name} comment analysis starting for {newPrs.Count:N0} pull requests");
             var analysisTimer = Stopwatch.StartNew();
-            var prAnalysis = pullRequestSnapshots
+            var prAnalysis = newPrs
                 .Select(pr => _prAnalyzer.CalculatePullRequestMetrics(pr))
                 .ToList();
             analysisTimer.Stop();
-            _logger.Information($"{Name} comment analysis completed for {pullRequestSnapshots.Count:N0} pull requests in {analysisTimer.Elapsed.ToMicroseconds():N0} microseconds");
+            _logger.Information($"{Name} comment analysis completed for {newPrs.Count:N0} pull requests in {analysisTimer.Elapsed.ToMicroseconds():N0} microseconds");
             
-            _logger.Information($"{Name} repository analysis starting for {pullRequestSnapshots.Count:N0} pull requests");
+            _logger.Information($"{Name} repository analysis starting for {newPrs.Count:N0} pull requests");
             analysisTimer = Stopwatch.StartNew();
             var repoAnalysis = _repoAnalyzer.CalculateRepositoryMetrics(prAnalysis);
             analysisTimer.Stop();
-            _logger.Information($"{Name} repository analysis completed for {pullRequestSnapshots.Count:N0} pull requests in {analysisTimer.Elapsed.ToMicroseconds():N0} microseconds");
+            _logger.Information($"{Name} repository analysis completed for {newPrs.Count:N0} pull requests in {analysisTimer.Elapsed.ToMicroseconds():N0} microseconds");
 
             await _analysisManager.SaveAsync(_repoManager.RepoOwner, _repoManager.RepoName, _clock.DateTimeUtcNow(), repoAnalysis);
 

--- a/RepoMan/RepoMan/Repository/RepositoryManager.cs
+++ b/RepoMan/RepoMan/Repository/RepositoryManager.cs
@@ -122,7 +122,7 @@ namespace RepoMan.Repository
         /// </summary>
         /// <param name="stateFilter"></param>
         /// <returns>A dictionary of pull requests that are new or that have been updated since the cache was last saved.</returns>
-        public async Task<IDictionary<int, PullRequestDetails>> RefreshFromUpstreamAsync(ItemStateFilter stateFilter)
+        public async Task<IList<PullRequestDetails>> RefreshFromUpstreamAsync(ItemStateFilter stateFilter)
         {
             var prs = await _prReader.GetPullRequestsRootAsync(stateFilter);
             var unknownPrs = new List<PullRequestDetails>();            
@@ -146,7 +146,7 @@ namespace RepoMan.Repository
                 await PersistCacheAsync();
             }
 
-            return completedPrs.ToDictionary(pr => pr.Number);
+            return completedPrs;
         }
 
         /// <summary>

--- a/RepoMan/RepoMan/Repository/RepositoryManager.cs
+++ b/RepoMan/RepoMan/Repository/RepositoryManager.cs
@@ -118,10 +118,6 @@ namespace RepoMan.Repository
             return repoHistoryMgr;
         }
 
-        /// <summary>
-        /// </summary>
-        /// <param name="stateFilter"></param>
-        /// <returns>A dictionary of pull requests that are new or that have been updated since the cache was last saved.</returns>
         public async Task<IList<PullRequestDetails>> RefreshFromUpstreamAsync(ItemStateFilter stateFilter)
         {
             var prs = await _prReader.GetPullRequestsRootAsync(stateFilter);

--- a/RepoMan/RepoMan/Repository/RepositoryManager.cs
+++ b/RepoMan/RepoMan/Repository/RepositoryManager.cs
@@ -130,8 +130,8 @@ namespace RepoMan.Repository
             try
             {
                 await _byNumberLock.WaitAsync();
-                var unknownPrsQuery = prs.Where(pr => !_byNumber.ContainsKey(pr.Number) || _byNumber[pr.Number].IsFullyInterrogated == false);
-                unknownPrs.AddRange(unknownPrsQuery);
+                var newOrUpdatedPullRequestsQuery = prs.Where(pr => !_byNumber.ContainsKey(pr.Number) || _byNumber[pr.Number].UpdatedAt <= pr.UpdatedAt);
+                unknownPrs.AddRange(newOrUpdatedPullRequestsQuery);
             }
             finally
             {

--- a/RepoMan/RepoMan/Repository/RepositoryManager.cs
+++ b/RepoMan/RepoMan/Repository/RepositoryManager.cs
@@ -121,8 +121,8 @@ namespace RepoMan.Repository
         /// <summary>
         /// </summary>
         /// <param name="stateFilter"></param>
-        /// <returns></returns>
-        public async Task RefreshFromUpstreamAsync(ItemStateFilter stateFilter)
+        /// <returns>A dictionary of pull requests that are new or that have been updated since the cache was last saved.</returns>
+        public async Task<IDictionary<int, PullRequestDetails>> RefreshFromUpstreamAsync(ItemStateFilter stateFilter)
         {
             var prs = await _prReader.GetPullRequestsRootAsync(stateFilter);
             var unknownPrs = new List<PullRequestDetails>();            
@@ -145,6 +145,8 @@ namespace RepoMan.Repository
                 await UpdateMemoryCacheAsync(completedPrs);
                 await PersistCacheAsync();
             }
+
+            return completedPrs.ToDictionary(pr => pr.Number);
         }
 
         /// <summary>


### PR DESCRIPTION
Commit messages are self explanatory:

* Use UpdatedAt timestamp to determine whether a PR needs to be re-cached
* Return the fully populated pull request details for PRs that haven't been seen before
* Only compute PR and repo statistics on pull requests that haven't been seen before 
* Keep track of the pull request numbers associated with each new repository health run

Closes #6 
Closes #16 