### PR TITLE
References to Octokit outside the Repository namespace are code smells, as is noted in the TextMatchingApprovalAnalyzer which should be revisited at some point

### DIFF
--- a/RepoMan/RepoMan/Analysis/ApprovalAnalyzers/TextMatchingApprovalAnalyzer.cs
+++ b/RepoMan/RepoMan/Analysis/ApprovalAnalyzers/TextMatchingApprovalAnalyzer.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using RepoMan.Records;
+using RepoMan.Repository;
 
 namespace RepoMan.Analysis.ApprovalAnalyzers
 {

--- a/RepoMan/RepoMan/Repository/OctokitExtensions.cs
+++ b/RepoMan/RepoMan/Repository/OctokitExtensions.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using Octokit;
+using RepoMan.Records;
+using User = RepoMan.Records.User;
 
-namespace RepoMan.Records
+namespace RepoMan.Repository
 {
     public static class OctokitExtensions
     {


### PR DESCRIPTION
References to Octokit outside the Repository namespace are code smells, as is noted in the TextMatchingApprovalAnalyzer which should be revisited at some point