### PR TITLE
Full url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# macOS
+.DS_Store
+
 # Serialized data files to mess with
 scratch/
 *.secret

--- a/RepoMan/RepoMan.UnitTests/RepoMan.UnitTests.csproj
+++ b/RepoMan/RepoMan.UnitTests/RepoMan.UnitTests.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.0</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/RepoMan/RepoMan/RepoMan.csproj
+++ b/RepoMan/RepoMan/RepoMan.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.0</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
         <LangVersion>8</LangVersion>
     </PropertyGroup>
 

--- a/RepoMan/RepoMan/Repository/BitBucketCloudPullRequestReader.cs
+++ b/RepoMan/RepoMan/Repository/BitBucketCloudPullRequestReader.cs
@@ -33,7 +33,8 @@ namespace RepoMan.Repository
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _bbClient = client ?? throw new ArgumentNullException(nameof(client));
 
-            var fullUrl = new Uri(uriHost, "!api/2.0");
+            var authority = new Uri(uriHost.GetLeftPart(UriPartial.Authority), UriKind.Absolute);
+            var fullUrl = new Uri(authority, "!api/2.0");
             _prApiUrl = $"{fullUrl}/repositories/{repoOwner}/{repoName}/pullrequests";
         }
 

--- a/RepoMan/RepoMan/Repository/GitHubPullRequestReaderFactory.cs
+++ b/RepoMan/RepoMan/Repository/GitHubPullRequestReaderFactory.cs
@@ -30,8 +30,9 @@ namespace RepoMan.Repository
             {
                 return existingClient;
             }
-            
-            var github = new Uri(repo.Url);
+
+            var authority = new Uri(repo.Url).GetLeftPart(UriPartial.Authority);
+            var github = new Uri(authority, UriKind.Absolute);
             var client = new GitHubClient(new ProductHeaderValue(_productHeaderValue), github);
             var auth = new Credentials(repo.ApiToken);
             client.Credentials = auth;

--- a/RepoMan/RepoMan/Repository/RepoWorker.cs
+++ b/RepoMan/RepoMan/Repository/RepoWorker.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Runtime.InteropServices.ComTypes;
 using System.Threading.Tasks;
 using RepoMan.Analysis;
 using RepoMan.IO;

--- a/RepoMan/Scratch/Scratch.csproj
+++ b/RepoMan/Scratch/Scratch.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.0</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This results in serialized data that looks like this:

```
{
  "owner": "alex",
  "name": "nyt-2020-election-scraper",
  "url": "https://github.com/alex/nyt-2020-election-scraper",
  "createdAt": "2020-12-23T21:12:29.018742+00:00",
  "updatedAt": "2020-12-23T21:12:29.018742+00:00",
  "pullRequestCount": 229,
  "scorers": [
    {
      "attribute": "UniqueCommenterCount",
      "scoreMultiplier": "15.00"
    },
```
instead of just having the url be github.com.