### PR TITLE
Use Markdown parser for scoring

### DIFF
--- a/RepoInspector/RepoInspector.Runner/Program.cs
+++ b/RepoInspector/RepoInspector.Runner/Program.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using System.Runtime.Loader;
 using System.Threading;
 using System.Threading.Tasks;
+using Markdig;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -80,6 +81,8 @@ namespace RepoInspector.Runner
                 .AddSingleton(sp => new FilesystemDataProvider(sp.GetRequiredService<IFilesystem>(), _scratchDir, sp.GetRequiredService<JsonSerializerSettings>()))
                 .AddSingleton<IPullRequestCacheManager>(sp => sp.GetRequiredService<FilesystemDataProvider>())
                 .AddSingleton<IAnalysisManager>(sp => sp.GetRequiredService<FilesystemDataProvider>())
+                // Do this so that we *can* modify our Markdown pipeline later on if we need to.
+                .AddSingleton(new MarkdownPipelineBuilder().Build())
                 // CommentScorers
                 .AddSingleton<UrlScorer>()
                 .AddSingleton<CodeFenceScorer>()

--- a/RepoInspector/RepoInspector.UnitTests/CodeBlockTests.cs
+++ b/RepoInspector/RepoInspector.UnitTests/CodeBlockTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using Markdig;
 using NUnit.Framework;
 using NUnit.Framework.Interfaces;
 using RepoInspector.Analysis.Scoring;
@@ -8,8 +9,8 @@ namespace RepoInspector.UnitTests
 {
     public class CodeBlockTests
     {
-        private static readonly CodeFragmentScorer _fragmentCounter = new CodeFragmentScorer();
-        private static readonly CodeFenceScorer _fenceCounter = new CodeFenceScorer();
+        private static readonly CodeFragmentScorer _fragmentCounter = new(new MarkdownPipelineBuilder().Build());
+        private static readonly CodeFenceScorer _fenceCounter = new(new MarkdownPipelineBuilder().Build());
         const string s = "```this is not a code block``` but it is a code fragment, as is `this`!";
 
         [Test, TestCaseSource(nameof(CodeFenceTestCases))]

--- a/RepoInspector/RepoInspector.UnitTests/ScorerTests.cs
+++ b/RepoInspector/RepoInspector.UnitTests/ScorerTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Markdig;
 using NUnit.Framework;
 using RepoInspector.Analysis.Scoring;
 using RepoInspector.Records;
@@ -8,9 +9,8 @@ namespace RepoInspector.UnitTests
 {
     public class ScorerTests
     {
-        private static readonly DateTimeOffset _now = DateTimeOffset.Now;
-        private static readonly CodeFragmentScorer _fragmentScorer = new CodeFragmentScorer();
-        private static readonly CodeFenceScorer _fenceScorer = new CodeFenceScorer();
+        private static readonly CodeFragmentScorer _fragmentScorer = new(new MarkdownPipelineBuilder().Build());
+        private static readonly CodeFenceScorer _fenceScorer = new(new MarkdownPipelineBuilder().Build());
 
         [Test]
         public void BigStringTest()
@@ -28,7 +28,7 @@ namespace RepoInspector.UnitTests
             
             // Crazy github string has 5 code fences, and 2 code fragments = score of 54
             var fragmentScore = _fragmentScorer.GetScore(prDetail);
-            var fenceScore = new CodeFenceScorer().GetScore(prDetail);
+            var fenceScore = _fenceScorer.GetScore(prDetail);
             
             var codeScore = fragmentScore.Points + fenceScore.Points;
             var shouldBeZero = expectedScore - codeScore;

--- a/RepoInspector/RepoInspector/Analysis/Scoring/CodeFragmentScorer.cs
+++ b/RepoInspector/RepoInspector/Analysis/Scoring/CodeFragmentScorer.cs
@@ -1,6 +1,10 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using Markdig;
+using Markdig.Syntax;
+using Markdig.Syntax.Inlines;
 using RepoInspector.Records;
 
 namespace RepoInspector.Analysis.Scoring
@@ -11,6 +15,13 @@ namespace RepoInspector.Analysis.Scoring
         public const string Label = "CodeFragmentCount";
         public override string Attribute => Label;
         public override double ScoreMultiplier => 2;
+
+        private readonly MarkdownPipeline _markdownPipeline;
+
+        public CodeFragmentScorer(MarkdownPipeline markdownPipeline)
+        {
+            _markdownPipeline = markdownPipeline ?? throw new ArgumentNullException(nameof(markdownPipeline));
+        }
         
         // This one doesn't support balanced ticks. I.e. ```foo``` is rendered the same as ``foo``. Maybe we could extend this later, but I don't have
         // time to become an expert on balancing groups in .NET regular expressions while my daughter is taking a nap.
@@ -24,11 +35,11 @@ namespace RepoInspector.Analysis.Scoring
             
             return codeFenceCount;
         }
-        
-        
+
+
         public override IEnumerable<string> Extract(string s)
             => string.IsNullOrWhiteSpace(s)
                 ? Enumerable.Empty<string>()
-                : _codeFragment.Matches(s).Select(m => m.Value);
+                : Markdown.Parse(s, _markdownPipeline).Descendants().OfType<CodeInline>().Select(ci => ci.Content);
     }
 }

--- a/RepoInspector/RepoInspector/RepoInspector.csproj
+++ b/RepoInspector/RepoInspector/RepoInspector.csproj
@@ -26,6 +26,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="Markdig" Version="0.23.0" />
       <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
       <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="5.0.0" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />


### PR DESCRIPTION
Use Markdig to extract fences and blocks for scoring in comments.

Fixes #37.